### PR TITLE
Make safari works with cockpit apps

### DIFF
--- a/app/controllers/beyond_canvas/authentications_controller.rb
+++ b/app/controllers/beyond_canvas/authentications_controller.rb
@@ -15,6 +15,7 @@ module BeyondCanvas
                   only: :new,
                   unless: -> { Rails.env.development? && BeyondCanvas.configuration.client_credentials }
     before_action :clear_locale_cookie, only: [:new, :install]
+    before_action :set_iframe_ancestor_url, only: :open_app
 
     def new
       @shop = Shop.find_or_initialize_by(beyond_api_url: params[:api_url])
@@ -82,6 +83,10 @@ module BeyondCanvas
 
     def clear_locale_cookie
       cookies.delete :locale if BeyondCanvas.configuration.cockpit_app
+    end
+
+    def set_iframe_ancestor_url
+      session[:iframe_ancestor_url] = request.referer
     end
   end
 end

--- a/app/controllers/beyond_canvas/authentications_controller.rb
+++ b/app/controllers/beyond_canvas/authentications_controller.rb
@@ -15,7 +15,6 @@ module BeyondCanvas
                   only: :new,
                   unless: -> { Rails.env.development? && BeyondCanvas.configuration.client_credentials }
     before_action :clear_locale_cookie, only: [:new, :install]
-    before_action :set_iframe_ancestor_url, only: :open_app
 
     def new
       @shop = Shop.find_or_initialize_by(beyond_api_url: params[:api_url])
@@ -74,6 +73,8 @@ module BeyondCanvas
 
       reset_session
       log_in shop
+
+      set_iframe_ancestor_url
 
       cookies.delete(:custom_styles_url)
       set_custom_styles_url shop if BeyondCanvas.configuration.custom_styles?

--- a/app/controllers/beyond_canvas/authentications_controller.rb
+++ b/app/controllers/beyond_canvas/authentications_controller.rb
@@ -74,6 +74,8 @@ module BeyondCanvas
       reset_session
       log_in shop
 
+      set_iframe_ancestor_url
+
       cookies.delete(:custom_styles_url)
       set_custom_styles_url shop if BeyondCanvas.configuration.custom_styles?
 
@@ -82,6 +84,10 @@ module BeyondCanvas
 
     def clear_locale_cookie
       cookies.delete :locale if BeyondCanvas.configuration.cockpit_app
+    end
+
+    def set_iframe_ancestor_url
+      session[:iframe_ancestor_url] = request.referer
     end
   end
 end

--- a/app/controllers/beyond_canvas/authentications_controller.rb
+++ b/app/controllers/beyond_canvas/authentications_controller.rb
@@ -74,8 +74,6 @@ module BeyondCanvas
       reset_session
       log_in shop
 
-      set_iframe_ancestor_url
-
       cookies.delete(:custom_styles_url)
       set_custom_styles_url shop if BeyondCanvas.configuration.custom_styles?
 
@@ -84,10 +82,6 @@ module BeyondCanvas
 
     def clear_locale_cookie
       cookies.delete :locale if BeyondCanvas.configuration.cockpit_app
-    end
-
-    def set_iframe_ancestor_url
-      session[:iframe_ancestor_url] = request.referer
     end
   end
 end

--- a/app/helpers/beyond_canvas/authentications_helper.rb
+++ b/app/helpers/beyond_canvas/authentications_helper.rb
@@ -17,7 +17,7 @@ module BeyondCanvas
     #
     def current_shop
       puts '*' * 75
-      puts session[:iframe_ancestor_url]
+      puts request
       puts '*' * 75
       if session[:shop_id]
         @current_shop ||= Shop.find_by(id: session[:shop_id])

--- a/app/helpers/beyond_canvas/authentications_helper.rb
+++ b/app/helpers/beyond_canvas/authentications_helper.rb
@@ -19,6 +19,7 @@ module BeyondCanvas
       puts '*' * 75
       puts request.session
       puts "PATH: #{request.path}"
+      puts "SAFARI COOKIE FIXED: #{request.session[:safari_cookie_fixed]}"
       puts '*' * 75
       if session[:shop_id]
         @current_shop ||= Shop.find_by(id: session[:shop_id])

--- a/app/helpers/beyond_canvas/authentications_helper.rb
+++ b/app/helpers/beyond_canvas/authentications_helper.rb
@@ -6,6 +6,9 @@ module BeyondCanvas
     # Logs in the given shop
     #
     def log_in(shop)
+      cookies[:shop_id] = {
+        value: shop.id
+      }.merge COOKIES_ATTRIBUTES
       session[:shop_id] = shop.id
     end
 

--- a/app/helpers/beyond_canvas/authentications_helper.rb
+++ b/app/helpers/beyond_canvas/authentications_helper.rb
@@ -17,7 +17,7 @@ module BeyondCanvas
     #
     def current_shop
       puts '*' * 75
-      puts request
+      puts request.session[:shop_id]
       puts '*' * 75
       if session[:shop_id]
         @current_shop ||= Shop.find_by(id: session[:shop_id])

--- a/app/helpers/beyond_canvas/authentications_helper.rb
+++ b/app/helpers/beyond_canvas/authentications_helper.rb
@@ -18,6 +18,7 @@ module BeyondCanvas
     def current_shop
       puts '*' * 75
       puts request.session
+      puts "PATH: #{request.path}"
       puts '*' * 75
       if session[:shop_id]
         @current_shop ||= Shop.find_by(id: session[:shop_id])

--- a/app/helpers/beyond_canvas/authentications_helper.rb
+++ b/app/helpers/beyond_canvas/authentications_helper.rb
@@ -13,6 +13,9 @@ module BeyondCanvas
     # Returns the current logged-in shop (if any)
     #
     def current_shop
+      puts '*' * 75
+      puts session[:iframe_ancestor_url]
+      puts '*' * 75
       if session[:shop_id]
         @current_shop ||= Shop.find_by(id: session[:shop_id])
       end

--- a/app/helpers/beyond_canvas/authentications_helper.rb
+++ b/app/helpers/beyond_canvas/authentications_helper.rb
@@ -6,9 +6,6 @@ module BeyondCanvas
     # Logs in the given shop
     #
     def log_in(shop)
-      cookies[:shop_id] = {
-        value: shop.id
-      }.merge COOKIES_ATTRIBUTES
       session[:shop_id] = shop.id
     end
 
@@ -16,11 +13,6 @@ module BeyondCanvas
     # Returns the current logged-in shop (if any)
     #
     def current_shop
-      puts '*' * 75
-      puts request.session
-      puts "PATH: #{request.path}"
-      puts "SAFARI COOKIE FIXED: #{request.session[:safari_cookie_fixed]}"
-      puts '*' * 75
       if session[:shop_id]
         @current_shop ||= Shop.find_by(id: session[:shop_id])
       end

--- a/app/helpers/beyond_canvas/authentications_helper.rb
+++ b/app/helpers/beyond_canvas/authentications_helper.rb
@@ -17,7 +17,7 @@ module BeyondCanvas
     #
     def current_shop
       puts '*' * 75
-      puts request.session[:shop_id]
+      puts request.session
       puts '*' * 75
       if session[:shop_id]
         @current_shop ||= Shop.find_by(id: session[:shop_id])

--- a/lib/beyond_canvas/engine.rb
+++ b/lib/beyond_canvas/engine.rb
@@ -19,9 +19,8 @@ module BeyondCanvas
 
     initializer 'beyond_canvas.session' do |app|
       if BeyondCanvas.configuration.cockpit_app == true && Rails.env.production?
-        app.config.session_store :cache_store, {
-          key: '_beyond_canvas',
-          serializer: :json,
+        app.config.session_store :cookie_store, {
+          domain: :all,
           secure: true,
           same_site: :none,
         }

--- a/lib/beyond_canvas/engine.rb
+++ b/lib/beyond_canvas/engine.rb
@@ -23,7 +23,7 @@ module BeyondCanvas
           domain: :all,
           secure: true,
           same_site: :none,
-          path: '/'
+          path: '/exports'
         }
       end
     end

--- a/lib/beyond_canvas/engine.rb
+++ b/lib/beyond_canvas/engine.rb
@@ -21,8 +21,7 @@ module BeyondCanvas
       if BeyondCanvas.configuration.cockpit_app == true && Rails.env.production?
         app.config.session_store :cookie_store, {
           secure: true,
-          same_site: :none,
-          path: '/'
+          same_site: :none
         }
       end
     end

--- a/lib/beyond_canvas/engine.rb
+++ b/lib/beyond_canvas/engine.rb
@@ -20,10 +20,9 @@ module BeyondCanvas
     initializer 'beyond_canvas.session' do |app|
       if BeyondCanvas.configuration.cockpit_app == true && Rails.env.production?
         app.config.session_store :cookie_store, {
-          domain: :all,
           secure: true,
           same_site: :none,
-          path: '/exports'
+          path: '/'
         }
       end
     end

--- a/lib/beyond_canvas/engine.rb
+++ b/lib/beyond_canvas/engine.rb
@@ -23,6 +23,7 @@ module BeyondCanvas
           domain: :all,
           secure: true,
           same_site: :none,
+          path: '/'
         }
       end
     end

--- a/lib/beyond_canvas/engine.rb
+++ b/lib/beyond_canvas/engine.rb
@@ -20,6 +20,8 @@ module BeyondCanvas
     initializer 'beyond_canvas.session' do |app|
       if BeyondCanvas.configuration.cockpit_app == true && Rails.env.production?
         app.config.session_store :cache_store, {
+          key: '_beyond_canvas',
+          serializer: :json,
           secure: true,
           same_site: :none,
         }

--- a/lib/beyond_canvas/engine.rb
+++ b/lib/beyond_canvas/engine.rb
@@ -19,7 +19,7 @@ module BeyondCanvas
 
     initializer 'beyond_canvas.session' do |app|
       if BeyondCanvas.configuration.cockpit_app == true && Rails.env.production?
-        app.config.session_store :cookie_store, {
+        app.config.session_store :cache_store, {
           secure: true,
           same_site: :none,
         }

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -18,7 +18,7 @@ module BeyondCanvas
           if sec_fetch_dest.blank?
             headers['X-Frame-Options'] = 'ALLOWALL'
             puts '_' * 100
-            puts request.user_agent
+            puts "USER AGENT: #{request.user_agent}"
             puts '_' * 100
           end
         end

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -11,7 +11,7 @@ module BeyondCanvas
 
         if request.headers['Sec-Fetch-Dest'] == 'iframe'
           headers['Content-Security-Policy'] = <<~POLICY.gsub "\n", ' '
-            frame-ancestors #{session[:iframe_ancestor_url] request.referer};
+            frame-ancestors #{session[:iframe_ancestor_url]} #{request.referer};
           POLICY
         end
 

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -11,7 +11,7 @@ module BeyondCanvas
 
         if request.headers['Sec-Fetch-Dest'] == 'iframe'
           headers['Content-Security-Policy'] = <<~POLICY.gsub "\n", ' '
-            frame-ancestors #{request.referer};
+            frame-ancestors #{session[:iframe_ancestor_url]};
           POLICY
         end
 

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -11,9 +11,11 @@ module BeyondCanvas
         sec_fetch_dest = request.headers['Sec-Fetch-Dest']
 
         if sec_fetch_dest == 'iframe' || (request.user_agent.match?(/Safari/) && sec_fetch_dest.blank?)
-        headers['Content-Security-Policy'] = <<~POLICY.gsub "\n", ' '
-          frame-ancestors #{request.session[:iframe_ancestor_url]} #{request.referer};
-        POLICY
+          headers['Content-Security-Policy'] = <<~POLICY.gsub "\n", ' '
+            frame-ancestors #{request.session[:iframe_ancestor_url]} #{request.referer};
+          POLICY
+
+          headers['X-Frame-Options'] = 'ALLOWALL' if sec_fetch_dest.blank?
         end
 
         [status, headers, response]

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -10,10 +10,10 @@ module BeyondCanvas
         request = ActionDispatch::Request.new env
 
         if request.headers['Sec-Fetch-Dest'] == 'iframe'
-          headers['Content-Security-Policy'] = <<~POLICY.gsub "\n", ' '
-            frame-ancestors #{request.session[:iframe_ancestor_url]} #{request.referer};
-          POLICY
         end
+        headers['Content-Security-Policy'] = <<~POLICY.gsub "\n", ' '
+          frame-ancestors #{request.session[:iframe_ancestor_url]} #{request.referer};
+        POLICY
 
         puts '-' * 75
         puts "CockpitAppHeader: #{request.path}"
@@ -22,7 +22,6 @@ module BeyondCanvas
         puts "CockpitAppHeader: #{request.headers['Sec-Fetch-Mode']}"
         puts "CockpitAppHeader: #{request.headers['Sec-Fetch-User']}"
         puts "CockpitAppHeader: #{request.user_agent}"
-        puts "CockpitAppHeader: #{request.headers['User-Agent']}"
         puts "CockpitAppHeader: #{request.headers['Accept']}"
         puts "CockpitAppHeader: #{request.headers['Accept-Encoding']}"
         puts "CockpitAppHeader: #{request.headers['Accept-Language']}"

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -10,16 +10,17 @@ module BeyondCanvas
         request = ActionDispatch::Request.new env
         sec_fetch_dest = request.headers['Sec-Fetch-Dest']
 
+        puts '_' * 80
+        puts "Cockpit Sessions: #{request.session}"
+        puts "Cockpit Sessions: #{request.session[:locale]}"
+        puts "Cockpit Sessions: #{request.session[:custom_styles_url]}"
+
         if sec_fetch_dest == 'iframe' || (request.user_agent.match?(/Safari/) && sec_fetch_dest.blank?)
           headers['Content-Security-Policy'] = <<~POLICY.gsub "\n", ' '
             frame-ancestors #{request.session[:iframe_ancestor_url]} #{request.referer};
           POLICY
         end
 
-        puts '_' * 80
-        puts "Cockpit Sessions: #{request.session}"
-        puts "Cockpit Sessions: #{request.session[:locale]}"
-        puts "Cockpit Sessions: #{request.session[:custom_styles_url]}"
         puts "Cockpit Sessions: #{request.session[:iframe_ancestor_url]}"
         puts '_' * 80
 

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -15,24 +15,6 @@ module BeyondCanvas
           POLICY
         end
 
-        puts '-' * 75
-        puts "CockpitAppHeader: #{request.path}"
-        puts "CockpitAppHeader: #{request.headers['Sec-Fetch-Dest']}"
-        puts "CockpitAppHeader: #{request.headers['Sec-Fetch-Site']}"
-        puts "CockpitAppHeader: #{request.headers['Sec-Fetch-Mode']}"
-        puts "CockpitAppHeader: #{request.headers['Sec-Fetch-User']}"
-        puts "CockpitAppHeader: #{request.user_agent}"
-        puts "CockpitAppHeader: #{request.headers['User-Agent']}"
-        puts "CockpitAppHeader: #{request.headers['Accept']}"
-        puts "CockpitAppHeader: #{request.headers['Accept-Encoding']}"
-        puts "CockpitAppHeader: #{request.headers['Accept-Language']}"
-        puts "CockpitAppHeader: #{request.headers['Cache-Control']}"
-        puts "CockpitAppHeader: #{request.headers['Connection']}"
-        puts "CockpitAppHeader: #{request.headers['Host']}"
-        puts "CockpitAppHeader: #{request.headers['Origin']}"
-        puts "CockpitAppHeader: #{request.headers['Referer']}"
-        puts '-' * 75
-
         [status, headers, response]
       end
     end

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -11,7 +11,7 @@ module BeyondCanvas
 
         if request.headers['Sec-Fetch-Dest'] == 'iframe'
           headers['Content-Security-Policy'] = <<~POLICY.gsub "\n", ' '
-            frame-ancestors #{session[:iframe_ancestor_url]};
+            frame-ancestors #{session[:iframe_ancestor_url] request.referer};
           POLICY
         end
 

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -30,6 +30,7 @@ module BeyondCanvas
         end
 
         request.session[:safari_cookie_fixed] = true if request.user_agent.match?(/Safari/)
+        puts "Cockpit Sessions: #{request.session[:safari_cookie_fixed]}"
 
         puts "Cockpit Sessions: #{request.session[:iframe_ancestor_url]}"
         puts '_' * 80

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -29,6 +29,8 @@ module BeyondCanvas
           POLICY
         end
 
+        request.session[:set_safari_seesion] = true if request.user_agent.match?(/Safari/)
+
         puts "Cockpit Sessions: #{request.session[:iframe_ancestor_url]}"
         puts '_' * 80
 

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -15,7 +15,12 @@ module BeyondCanvas
             frame-ancestors #{request.session[:iframe_ancestor_url]} #{request.referer};
           POLICY
 
-          headers['X-Frame-Options'] = 'ALLOWALL' if sec_fetch_dest.blank?
+          if sec_fetch_dest.blank?
+            headers['X-Frame-Options'] = 'ALLOWALL'
+            puts '_' * 100
+            puts request.user_agent
+            puts '_' * 100
+          end
         end
 
         [status, headers, response]

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -17,6 +17,7 @@ module BeyondCanvas
 
         puts '-' * 75
         puts "CockpitAppHeader: #{request.path}"
+        puts "CockpitAppHeader: #{request.destination}"
         puts "CockpitAppHeader: #{request.headers['Sec-Fetch-Dest']}"
         puts "CockpitAppHeader: #{request.headers['Sec-Fetch-Site']}"
         puts "CockpitAppHeader: #{request.headers['Sec-Fetch-Mode']}"

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -18,6 +18,10 @@ module BeyondCanvas
         puts "Cockpit Sessions: #{request.session[:custom_styles_url]}"
         puts "Cockpit Sessions: #{request.session[:iframe_ancestor_url]}"
 
+        puts "Cockpit Cookies: #{request.cookies[:custom_styles_url]}"
+        puts "Cockpit Cookies: #{request.cookies[:locale]}"
+        puts "Cockpit Cookies: #{request.cookies[:shop_id]}"
+
         if sec_fetch_dest == 'iframe' || (request.user_agent.match?(/Safari/) && sec_fetch_dest.blank?)
           headers['Content-Security-Policy'] = <<~POLICY.gsub "\n", ' '
             frame-ancestors #{request.session[:iframe_ancestor_url]} #{request.referer};

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -18,6 +18,7 @@ module BeyondCanvas
         puts "Cockpit Sessions: #{request.session[:custom_styles_url]}"
         puts "Cockpit Sessions: #{request.session[:iframe_ancestor_url]}"
 
+        puts "Cockpit Cookies: #{request.cookies}"
         puts "Cockpit Cookies: #{request.cookies[:custom_styles_url]}"
         puts "Cockpit Cookies: #{request.cookies[:locale]}"
         puts "Cockpit Cookies: #{request.cookies[:shop_id]}"

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -23,11 +23,11 @@ module BeyondCanvas
         puts "Cockpit Cookies: #{request.cookies[:locale]}"
         puts "Cockpit Cookies: #{request.cookies[:shop_id]}"
 
-        if sec_fetch_dest == 'iframe' || (request.user_agent.match?(/Safari/) && sec_fetch_dest.blank?)
-          headers['Content-Security-Policy'] = <<~POLICY.gsub "\n", ' '
-            frame-ancestors #{request.session[:iframe_ancestor_url]} #{request.referer};
-          POLICY
-        end
+        # if sec_fetch_dest == 'iframe' || (request.user_agent.match?(/Safari/) && sec_fetch_dest.blank?)
+        headers['Content-Security-Policy'] = <<~POLICY.gsub "\n", ' '
+          frame-ancestors #{request.session[:iframe_ancestor_url]} #{request.referer};
+        POLICY
+        # end
 
         request.session[:safari_cookie_fixed] = true
         puts "Cockpit Sessions: #{request.session[:safari_cookie_fixed]}"

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -17,7 +17,7 @@ module BeyondCanvas
 
         puts '-' * 75
 
-        if request.user_agent.match?(/Macintosh/)
+        if request.user_agent.match?(/Macintosh/) && request.headers['Sec-Fetch-Dest'].blank?
           puts "Safari: #{request.user_agent}"
         end
 

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -21,7 +21,6 @@ module BeyondCanvas
         puts "Cockpit Cookies: #{request.cookies}"
         puts "Cockpit Cookies: #{request.cookies[:custom_styles_url]}"
         puts "Cockpit Cookies: #{request.cookies[:locale]}"
-        puts "Cockpit Cookies: #{request.cookies[:shop_id]}"
 
         # if sec_fetch_dest == 'iframe' || (request.user_agent.match?(/Safari/) && sec_fetch_dest.blank?)
         headers['Content-Security-Policy'] = <<~POLICY.gsub "\n", ' '

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -29,7 +29,7 @@ module BeyondCanvas
           POLICY
         end
 
-        request.session[:safari_cookie_fixed] = true if request.user_agent.match?(/Safari/)
+        request.session[:safari_cookie_fixed] = true
         puts "Cockpit Sessions: #{request.session[:safari_cookie_fixed]}"
 
         puts "Cockpit Sessions: #{request.session[:iframe_ancestor_url]}"

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -10,47 +10,11 @@ module BeyondCanvas
         request = ActionDispatch::Request.new env
         sec_fetch_dest = request.headers['Sec-Fetch-Dest']
 
-        # puts '_' * 80
-        # puts "Cockpit Sessions: #{request.session}"
-        # puts "Cockpit Cookies:  #{request.cookies}"
-        # puts "Cockpit Headers:  #{request.session[:shop_id]}"
-        # puts "Cockpit Sessions: #{request.session[:locale]}"
-        # puts "Cockpit Sessions: #{request.session[:custom_styles_url]}"
-        # puts "Cockpit Sessions: #{request.session[:iframe_ancestor_url]}"
-
-        # puts "Cockpit Cookies: #{request.cookies}"
-        # puts "Cockpit Cookies: #{request.cookies[:custom_styles_url]}"
-        # puts "Cockpit Cookies: #{request.cookies[:locale]}"
-
-        # if sec_fetch_dest == 'iframe' || (request.user_agent.match?(/Safari/) && sec_fetch_dest.blank?)
+        if sec_fetch_dest == 'iframe' || (request.user_agent.match?(/Safari/) && sec_fetch_dest.blank?)
         headers['Content-Security-Policy'] = <<~POLICY.gsub "\n", ' '
           frame-ancestors #{request.session[:iframe_ancestor_url]} #{request.referer};
         POLICY
-        # end
-
-        # request.session[:safari_cookie_fixed] = true
-        # puts "Cockpit Sessions: #{request.session[:safari_cookie_fixed]}"
-
-        # puts "Cockpit Sessions: #{request.session[:iframe_ancestor_url]}"
-        # puts '_' * 80
-
-
-        # puts '-' * 75
-        # puts "CockpitAppHeader: #{request.path}"
-        # puts "CockpitAppHeader: #{request.headers['Sec-Fetch-Dest']}"
-        # puts "CockpitAppHeader: #{request.headers['Sec-Fetch-Site']}"
-        # puts "CockpitAppHeader: #{request.headers['Sec-Fetch-Mode']}"
-        # puts "CockpitAppHeader: #{request.headers['Sec-Fetch-User']}"
-        # puts "CockpitAppHeader: #{request.user_agent}"
-        # puts "CockpitAppHeader: #{request.headers['Accept']}"
-        # puts "CockpitAppHeader: #{request.headers['Accept-Encoding']}"
-        # puts "CockpitAppHeader: #{request.headers['Accept-Language']}"
-        # puts "CockpitAppHeader: #{request.headers['Cache-Control']}"
-        # puts "CockpitAppHeader: #{request.headers['Connection']}"
-        # puts "CockpitAppHeader: #{request.headers['Host']}"
-        # puts "CockpitAppHeader: #{request.headers['Origin']}"
-        # puts "CockpitAppHeader: #{request.headers['Referer']}"
-        # puts '-' * 75
+        end
 
         [status, headers, response]
       end

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -14,13 +14,6 @@ module BeyondCanvas
           headers['Content-Security-Policy'] = <<~POLICY.gsub "\n", ' '
             frame-ancestors #{request.session[:iframe_ancestor_url]} #{request.referer};
           POLICY
-
-          if sec_fetch_dest.blank?
-            headers['X-Frame-Options'] = 'ALLOWALL'
-            puts '_' * 100
-            puts "USER AGENT: #{request.user_agent}"
-            puts '_' * 100
-          end
         end
 
         [status, headers, response]

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -16,6 +16,11 @@ module BeyondCanvas
         POLICY
 
         puts '-' * 75
+
+        if request.user_agent.match?(/Safari/)
+          puts "Safari: #{request.user_agent}"
+        end
+
         puts "CockpitAppHeader: #{request.path}"
         puts "CockpitAppHeader: #{request.headers['Sec-Fetch-Dest']}"
         puts "CockpitAppHeader: #{request.headers['Sec-Fetch-Site']}"

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -17,7 +17,7 @@ module BeyondCanvas
 
         puts '-' * 75
 
-        if request.user_agent.match?(/Safari/)
+        if request.user_agent.match?(/Macintosh/)
           puts "Safari: #{request.user_agent}"
         end
 

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -14,6 +14,7 @@ module BeyondCanvas
         puts "Cockpit Sessions: #{request.session}"
         puts "Cockpit Sessions: #{request.session[:locale]}"
         puts "Cockpit Sessions: #{request.session[:custom_styles_url]}"
+        puts "Cockpit Sessions: #{request.session[:iframe_ancestor_url]}"
 
         if sec_fetch_dest == 'iframe' || (request.user_agent.match?(/Safari/) && sec_fetch_dest.blank?)
           headers['Content-Security-Policy'] = <<~POLICY.gsub "\n", ' '

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -17,7 +17,6 @@ module BeyondCanvas
 
         puts '-' * 75
         puts "CockpitAppHeader: #{request.path}"
-        puts "CockpitAppHeader: #{request.destination}"
         puts "CockpitAppHeader: #{request.headers['Sec-Fetch-Dest']}"
         puts "CockpitAppHeader: #{request.headers['Sec-Fetch-Site']}"
         puts "CockpitAppHeader: #{request.headers['Sec-Fetch-Mode']}"

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -8,12 +8,13 @@ module BeyondCanvas
       def call(env)
         status, headers, response = @app.call(env)
         request = ActionDispatch::Request.new env
+        sec_fetch_dest = request.headers['Sec-Fetch-Dest']
 
-        if request.headers['Sec-Fetch-Dest'] == 'iframe'
+        if sec_fetch_dest == 'iframe' || (request.user_agent.match?(/Safari/) && sec_fetch_dest.blank?)
+          headers['Content-Security-Policy'] = <<~POLICY.gsub "\n", ' '
+            frame-ancestors #{request.session[:iframe_ancestor_url]} #{request.referer};
+          POLICY
         end
-        headers['Content-Security-Policy'] = <<~POLICY.gsub "\n", ' '
-          frame-ancestors #{request.session[:iframe_ancestor_url]} #{request.referer};
-        POLICY
 
         puts '-' * 75
 

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -16,12 +16,16 @@ module BeyondCanvas
           POLICY
         end
 
+        puts '_' * 80
+        puts "Cockpit Sessions: #{request.session}"
+        puts "Cockpit Sessions: #{request.session[:iframe_ancestor_url]}"
+        puts "Cockpit Sessions: #{request.session[:locale]}"
+        puts "Cockpit Sessions: #{request.session[:custom_styles_url]}"
+        puts "Cockpit Sessions: #{request.session[:iframe_ancestor_url]}"
+        puts '_' * 80
+
+
         puts '-' * 75
-
-        if request.user_agent.match?(/Macintosh/) && request.headers['Sec-Fetch-Dest'].blank?
-          puts "Safari: #{request.user_agent}"
-        end
-
         puts "CockpitAppHeader: #{request.path}"
         puts "CockpitAppHeader: #{request.headers['Sec-Fetch-Dest']}"
         puts "CockpitAppHeader: #{request.headers['Sec-Fetch-Site']}"

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -10,17 +10,17 @@ module BeyondCanvas
         request = ActionDispatch::Request.new env
         sec_fetch_dest = request.headers['Sec-Fetch-Dest']
 
-        puts '_' * 80
-        puts "Cockpit Sessions: #{request.session}"
-        puts "Cockpit Cookies:  #{request.cookies}"
-        puts "Cockpit Headers:  #{request.session[:shop_id]}"
-        puts "Cockpit Sessions: #{request.session[:locale]}"
-        puts "Cockpit Sessions: #{request.session[:custom_styles_url]}"
-        puts "Cockpit Sessions: #{request.session[:iframe_ancestor_url]}"
+        # puts '_' * 80
+        # puts "Cockpit Sessions: #{request.session}"
+        # puts "Cockpit Cookies:  #{request.cookies}"
+        # puts "Cockpit Headers:  #{request.session[:shop_id]}"
+        # puts "Cockpit Sessions: #{request.session[:locale]}"
+        # puts "Cockpit Sessions: #{request.session[:custom_styles_url]}"
+        # puts "Cockpit Sessions: #{request.session[:iframe_ancestor_url]}"
 
-        puts "Cockpit Cookies: #{request.cookies}"
-        puts "Cockpit Cookies: #{request.cookies[:custom_styles_url]}"
-        puts "Cockpit Cookies: #{request.cookies[:locale]}"
+        # puts "Cockpit Cookies: #{request.cookies}"
+        # puts "Cockpit Cookies: #{request.cookies[:custom_styles_url]}"
+        # puts "Cockpit Cookies: #{request.cookies[:locale]}"
 
         # if sec_fetch_dest == 'iframe' || (request.user_agent.match?(/Safari/) && sec_fetch_dest.blank?)
         headers['Content-Security-Policy'] = <<~POLICY.gsub "\n", ' '
@@ -28,29 +28,29 @@ module BeyondCanvas
         POLICY
         # end
 
-        request.session[:safari_cookie_fixed] = true
-        puts "Cockpit Sessions: #{request.session[:safari_cookie_fixed]}"
+        # request.session[:safari_cookie_fixed] = true
+        # puts "Cockpit Sessions: #{request.session[:safari_cookie_fixed]}"
 
-        puts "Cockpit Sessions: #{request.session[:iframe_ancestor_url]}"
-        puts '_' * 80
+        # puts "Cockpit Sessions: #{request.session[:iframe_ancestor_url]}"
+        # puts '_' * 80
 
 
-        puts '-' * 75
-        puts "CockpitAppHeader: #{request.path}"
-        puts "CockpitAppHeader: #{request.headers['Sec-Fetch-Dest']}"
-        puts "CockpitAppHeader: #{request.headers['Sec-Fetch-Site']}"
-        puts "CockpitAppHeader: #{request.headers['Sec-Fetch-Mode']}"
-        puts "CockpitAppHeader: #{request.headers['Sec-Fetch-User']}"
-        puts "CockpitAppHeader: #{request.user_agent}"
-        puts "CockpitAppHeader: #{request.headers['Accept']}"
-        puts "CockpitAppHeader: #{request.headers['Accept-Encoding']}"
-        puts "CockpitAppHeader: #{request.headers['Accept-Language']}"
-        puts "CockpitAppHeader: #{request.headers['Cache-Control']}"
-        puts "CockpitAppHeader: #{request.headers['Connection']}"
-        puts "CockpitAppHeader: #{request.headers['Host']}"
-        puts "CockpitAppHeader: #{request.headers['Origin']}"
-        puts "CockpitAppHeader: #{request.headers['Referer']}"
-        puts '-' * 75
+        # puts '-' * 75
+        # puts "CockpitAppHeader: #{request.path}"
+        # puts "CockpitAppHeader: #{request.headers['Sec-Fetch-Dest']}"
+        # puts "CockpitAppHeader: #{request.headers['Sec-Fetch-Site']}"
+        # puts "CockpitAppHeader: #{request.headers['Sec-Fetch-Mode']}"
+        # puts "CockpitAppHeader: #{request.headers['Sec-Fetch-User']}"
+        # puts "CockpitAppHeader: #{request.user_agent}"
+        # puts "CockpitAppHeader: #{request.headers['Accept']}"
+        # puts "CockpitAppHeader: #{request.headers['Accept-Encoding']}"
+        # puts "CockpitAppHeader: #{request.headers['Accept-Language']}"
+        # puts "CockpitAppHeader: #{request.headers['Cache-Control']}"
+        # puts "CockpitAppHeader: #{request.headers['Connection']}"
+        # puts "CockpitAppHeader: #{request.headers['Host']}"
+        # puts "CockpitAppHeader: #{request.headers['Origin']}"
+        # puts "CockpitAppHeader: #{request.headers['Referer']}"
+        # puts '-' * 75
 
         [status, headers, response]
       end

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -29,7 +29,7 @@ module BeyondCanvas
           POLICY
         end
 
-        request.session[:set_safari_seesion] = true if request.user_agent.match?(/Safari/)
+        request.session[:safari_cookie_fixed] = true if request.user_agent.match?(/Safari/)
 
         puts "Cockpit Sessions: #{request.session[:iframe_ancestor_url]}"
         puts '_' * 80

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -9,9 +9,6 @@ module BeyondCanvas
         status, headers, response = @app.call(env)
         request = ActionDispatch::Request.new env
 
-        session_key = (config.session_options || {})[:key]
-        session_data = request.cookie_jar.encrypted[session_key] || {}
-
         if request.headers['Sec-Fetch-Dest'] == 'iframe'
           headers['Content-Security-Policy'] = <<~POLICY.gsub "\n", ' '
             frame-ancestors #{request.session[:iframe_ancestor_url]} #{request.referer};

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -9,9 +9,12 @@ module BeyondCanvas
         status, headers, response = @app.call(env)
         request = ActionDispatch::Request.new env
 
+        session_key = (config.session_options || {})[:key]
+        session_data = request.cookie_jar.encrypted[session_key] || {}
+
         if request.headers['Sec-Fetch-Dest'] == 'iframe'
           headers['Content-Security-Policy'] = <<~POLICY.gsub "\n", ' '
-            frame-ancestors #{session[:iframe_ancestor_url]} #{request.referer};
+            frame-ancestors #{request.session[:iframe_ancestor_url]} #{request.referer};
           POLICY
         end
 

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -12,6 +12,8 @@ module BeyondCanvas
 
         puts '_' * 80
         puts "Cockpit Sessions: #{request.session}"
+        puts "Cockpit Cookies:  #{request.cookies}"
+        puts "Cockpit Headers:  #{request.session[:shop_id]}"
         puts "Cockpit Sessions: #{request.session[:locale]}"
         puts "Cockpit Sessions: #{request.session[:custom_styles_url]}"
         puts "Cockpit Sessions: #{request.session[:iframe_ancestor_url]}"

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -15,6 +15,24 @@ module BeyondCanvas
           POLICY
         end
 
+        puts '-' * 75
+        puts "CockpitAppHeader: #{request.path}"
+        puts "CockpitAppHeader: #{request.headers['Sec-Fetch-Dest']}"
+        puts "CockpitAppHeader: #{request.headers['Sec-Fetch-Site']}"
+        puts "CockpitAppHeader: #{request.headers['Sec-Fetch-Mode']}"
+        puts "CockpitAppHeader: #{request.headers['Sec-Fetch-User']}"
+        puts "CockpitAppHeader: #{request.user_agent}"
+        puts "CockpitAppHeader: #{request.headers['User-Agent']}"
+        puts "CockpitAppHeader: #{request.headers['Accept']}"
+        puts "CockpitAppHeader: #{request.headers['Accept-Encoding']}"
+        puts "CockpitAppHeader: #{request.headers['Accept-Language']}"
+        puts "CockpitAppHeader: #{request.headers['Cache-Control']}"
+        puts "CockpitAppHeader: #{request.headers['Connection']}"
+        puts "CockpitAppHeader: #{request.headers['Host']}"
+        puts "CockpitAppHeader: #{request.headers['Origin']}"
+        puts "CockpitAppHeader: #{request.headers['Referer']}"
+        puts '-' * 75
+
         [status, headers, response]
       end
     end

--- a/lib/beyond_canvas/middleware/cockpit_app_header.rb
+++ b/lib/beyond_canvas/middleware/cockpit_app_header.rb
@@ -18,7 +18,6 @@ module BeyondCanvas
 
         puts '_' * 80
         puts "Cockpit Sessions: #{request.session}"
-        puts "Cockpit Sessions: #{request.session[:iframe_ancestor_url]}"
         puts "Cockpit Sessions: #{request.session[:locale]}"
         puts "Cockpit Sessions: #{request.session[:custom_styles_url]}"
         puts "Cockpit Sessions: #{request.session[:iframe_ancestor_url]}"

--- a/public/500.html
+++ b/public/500.html
@@ -44,18 +44,18 @@
           "en": {
             translation: {
               title: "Something went wrong",
-              message: "We're sorry, there's been an internal error. Try refreshing the page. If this error persists, try again later or contact Support."
+              message: "We're sorry, there was an internal error. Try refreshing the page. If this error persists, try again later or contact Support. If you are using the browser Safari, please make sure that you have disabled the \"Prevent cross-site tracking\" setting."
             }
           },
           "de": {
             translation: {
               title: "Etwas ist schiefgelaufen",
-              message: "Es tut uns leid, ein interner Fehler ist aufgetreten. Versuche, die Seite neu zu laden. Wenn dieser Fehler weiterhin besteht, versuche es später noch einmal oder wende dich an den Support."
+              message: "Es tut uns leid, ein interner Fehler ist aufgetreten. Versuche, die Seite neu zu laden. Wenn dieser Fehler weiterhin besteht, versuche es später noch einmal oder wende dich an den Support. Wenn du den Browser \“Safari”\ verwendest, achte bitte darauf, dass du in den Einstellungen \“Websiteübergreifendes Tracking verhindern\“ deaktivierst."
             }
           },
           "fr": {
             title: "Une erreur s'est produite",
-            message: "Nous sommes désolés, une erreur interne s'est produite. Essaye de rafraîchir la page. Si cette erreur persiste, réessaye plus tard ou contacte le support client."
+            message: "Nous sommes désolés, une erreur interne s’est produite. Essaye de rafraîchir la page. Si cette erreur persiste, réessaye plus tard ou contacte le support client. Si tu utilises Safari comme navigateur, assure-toi d’avoir désactivé la fonctionnalité  \"Empêcher le suivi sur plusieurs domaines\"."
           }
         }
       }, function (err, t) {

--- a/public/500.html
+++ b/public/500.html
@@ -55,7 +55,7 @@
           },
           "fr": {
             title: "Une erreur s'est produite",
-            message: "Nous sommes désolés, une erreur interne s’est produite. Essaye de rafraîchir la page. Si cette erreur persiste, réessaye plus tard ou contacte le support client. Si tu utilises Safari comme navigateur, assure-toi d’avoir désactivé la fonctionnalité  \"Empêcher le suivi sur plusieurs domaines\"."
+            message: "Nous sommes désolés, une erreur interne s’est produite. Essaye de rafraîchir la page. Si cette erreur persiste, réessaye plus tard ou contacte le support client. Si tu utilises Safari comme navigateur, assure-toi d’avoir désactivé la fonctionnalité « Empêcher le suivi sur plusieurs domaines ».
           }
         }
       }, function (err, t) {

--- a/public/500.html
+++ b/public/500.html
@@ -55,7 +55,7 @@
           },
           "fr": {
             title: "Une erreur s'est produite",
-            message: "Nous sommes désolés, une erreur interne s’est produite. Essaye de rafraîchir la page. Si cette erreur persiste, réessaye plus tard ou contacte le support client. Si tu utilises Safari comme navigateur, assure-toi d’avoir désactivé la fonctionnalité « Empêcher le suivi sur plusieurs domaines ».
+            message: "Nous sommes désolés, une erreur interne s’est produite. Essaye de rafraîchir la page. Si cette erreur persiste, réessaye plus tard ou contacte le support client. Si tu utilises Safari comme navigateur, assure-toi d’avoir désactivé la fonctionnalité « Empêcher le suivi sur plusieurs domaines »."
           }
         }
       }, function (err, t) {


### PR DESCRIPTION
Due to this [feature](https://support.apple.com/en-gb/guide/safari/sfri40732/mac) Safari doesn't work as a cockpit app when **Prevent cross-site tracking** is enabled. For that reason, we updated the 500 error page to inform the user what have to do to make the app work.