### PR TITLE
EPT-2389: adds event on click to clear previous selected file

### DIFF
--- a/app/assets/javascripts/beyond_canvas/base.js
+++ b/app/assets/javascripts/beyond_canvas/base.js
@@ -154,11 +154,16 @@
       $('input[type="file"]').each(function() {
         var $input = $(this);
         var $label = $(".input__file__text." + $input.attr("id"));
-        var labelVal = $label.html();
+        var noFileText = $input.attr("data-no-file-text");
+        var svgFileIcon = '\n        <svg class="input__file__icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">\n          <path d="M15 2v5h5v15h-16v-20h11zm1-2h-14v24h20v-18l-6-6z"/>\n        </svg>';
         $input.on("change", function(e) {
           var fileName = "";
           if (this.files && this.files.length > 1) fileName = (this.getAttribute("data-multiple-caption") || "{count} files selected").replace("{count}", this.files.length); else if (e.target.value) fileName = e.target.value.split("\\").pop();
-          if (fileName) $label.html('<svg class="input__file__icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M15 2v5h5v15h-16v-20h11zm1-2h-14v24h20v-18l-6-6z"/></svg>' + fileName); else $label.html(labelVal);
+          if (fileName) {
+            $label.html("" + svgFileIcon + fileName);
+          } else {
+            $label.html(noFileText);
+          }
         });
         $input.on("focus", function() {
           $input.addClass("has-focus");
@@ -167,11 +172,22 @@
         });
       });
     };
+    var initializeClearOnClickInputs = function initializeClearOnClickInputs() {
+      $("form").on("click", 'input[type="file"][data-clear-on-click="true"]', function() {
+        var dt = new DataTransfer();
+        this.files = dt.files;
+        this.dispatchEvent(new Event("change", {
+          bubbles: true,
+          composed: true
+        }));
+      });
+    };
     $(document).on("ready page:load turbolinks:load", function() {
       var observer = new MutationObserver(function() {
         return onDOMReady();
       });
       onDOMReady();
+      initializeClearOnClickInputs();
       observer.observe(document.body, {
         childList: true,
         subtree: true

--- a/app/javascript/beyond_canvas/initializers/inputs.js
+++ b/app/javascript/beyond_canvas/initializers/inputs.js
@@ -45,8 +45,8 @@
     $('form').on('click', 'input[type="file"][data-clear-on-click="true"]', function () {
       // Clear previous selected files
       const dt = new DataTransfer();
-      this.files = dt.files;
 
+      this.files = dt.files;
       // Trigger change
       this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
     });

--- a/app/javascript/beyond_canvas/initializers/inputs.js
+++ b/app/javascript/beyond_canvas/initializers/inputs.js
@@ -3,7 +3,11 @@
     $('input[type="file"]').each(function () {
       const $input = $(this);
       const $label = $(`.input__file__text.${$input.attr('id')}`);
-      const labelVal = $label.html();
+      const noFileText = $input.attr('data-no-file-text');
+      const svgFileIcon = `
+        <svg class="input__file__icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+          <path d="M15 2v5h5v15h-16v-20h11zm1-2h-14v24h20v-18l-6-6z"/>
+        </svg>`;
 
       $input.on('change', function (e) {
         let fileName = '';
@@ -15,11 +19,13 @@
           );
         else if (e.target.value) fileName = e.target.value.split('\\').pop();
 
-        if (fileName)
-          $label.html(
-            `<svg class="input__file__icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M15 2v5h5v15h-16v-20h11zm1-2h-14v24h20v-18l-6-6z"/></svg>${fileName}`
-          );
-        else $label.html(labelVal);
+        if (fileName) {
+          // Adds icon + filename to label
+          $label.html(`${svgFileIcon}${fileName}`);
+        } else {
+          // Adds default no-file text
+          $label.html(noFileText);
+        }
       });
 
       // Firefox bug fix
@@ -33,10 +39,26 @@
     });
   };
 
+  // Clear previous files on click to upload a new file. This applies to the files
+  // inputs inside a form that has the data-clear-on-click="true" setted
+  const initializeClearOnClickInputs = function () {
+    $('form').on('click', 'input[type="file"][data-clear-on-click="true"]', function () {
+      // Clear previous selected files
+      const dt = new DataTransfer();
+      this.files = dt.files;
+
+      // Trigger change
+      this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+    });
+  };
+
   $(document).on('ready page:load turbolinks:load', () => {
     const observer = new MutationObserver(() => onDOMReady());
 
     onDOMReady();
+    initializeClearOnClickInputs();
+
     observer.observe(document.body, { childList: true, subtree: true });
   });
 })(jQuery);
+


### PR DESCRIPTION
## Task
Unexpected behaivor when loading a file with the same name twice. 

## Solution
Clear file input fields on click and tigger the change event to setup the view.
This change affects that if you click the input to upload a file but you cancel it, you will loose the previous file. This is the default expected behaviour of `html`.

## Usage
To add this behaviour to the input field you should add the `data-clear-on-click="true"` attribute to the html element. `f.file_field :images, data: { clear_on_click: true }` in RoR.