### PR TITLE
Fix js event firing multiple times

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,11 +4,9 @@
     "es6": true,
     "jquery": true
   },
-  "extends": [
-    "eslint:recommended"
-  ],
+  "extends": ["eslint:recommended"],
   "parserOptions": {
-    "ecmaVersion": 6,
+    "ecmaVersion": 11,
     "sourceType": "module"
   },
   "rules": {
@@ -28,14 +26,8 @@
         "allowTemplateLiterals": true
       }
     ],
-    "semi": [
-      "error",
-      "always"
-    ],
-    "init-declarations": [
-      "error",
-      "always"
-    ],
+    "semi": ["error", "always"],
+    "init-declarations": ["error", "always"],
     "no-undefined": "error"
   }
 }

--- a/app/assets/javascripts/beyond_canvas/base.js
+++ b/app/assets/javascripts/beyond_canvas/base.js
@@ -151,25 +151,41 @@
   });
   (function($) {
     var onDOMReady = function onDOMReady() {
-      $('input[type="file"]').each(function() {
-        var $input = $(this);
-        var $label = $(".input__file__text." + $input.attr("id"));
-        var noFileText = $input.attr("data-no-file-text");
+      updateInputLabel();
+      initializeClearOnClickInputs();
+      addInputFocusClass();
+      removeInputFocusClass();
+    };
+    var updateInputLabel = function updateInputLabel() {
+      $("form").on("change", 'input[type="file"]', function(_ref) {
+        var input = _ref.currentTarget;
+        var label = $(".input__file__text." + input.getAttribute("id"));
+        var noFileText = input.getAttribute("data-no-file-text");
         var svgFileIcon = '\n        <svg class="input__file__icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">\n          <path d="M15 2v5h5v15h-16v-20h11zm1-2h-14v24h20v-18l-6-6z"/>\n        </svg>';
-        $input.on("change", function(e) {
-          var fileName = "";
-          if (this.files && this.files.length > 1) fileName = (this.getAttribute("data-multiple-caption") || "{count} files selected").replace("{count}", this.files.length); else if (e.target.value) fileName = e.target.value.split("\\").pop();
-          if (fileName) {
-            $label.html("" + svgFileIcon + fileName);
-          } else {
-            $label.html(noFileText);
-          }
-        });
-        $input.on("focus", function() {
-          $input.addClass("has-focus");
-        }).on("blur", function() {
-          $input.removeClass("has-focus");
-        });
+        if (!label) return;
+        var fileName = "";
+        if (input.files && input.files.length > 1) {
+          fileName = (input.getAttribute("data-multiple-caption") || "{count} files selected").replace("{count}", input.files.length);
+        } else if (input.value) {
+          fileName = input.value.split("\\").pop();
+        }
+        if (fileName) {
+          label.html("" + svgFileIcon + fileName);
+        } else {
+          label.html(noFileText);
+        }
+      });
+    };
+    var addInputFocusClass = function addInputFocusClass() {
+      $("form").on("focus", 'input[type="file"]', function(_ref2) {
+        var input = _ref2.currentTarget;
+        input.addClass("has-focus");
+      });
+    };
+    var removeInputFocusClass = function removeInputFocusClass() {
+      $("form").on("blur", 'input[type="file"]', function(_ref3) {
+        var input = _ref3.currentTarget;
+        input.removeClass("has-focus");
       });
     };
     var initializeClearOnClickInputs = function initializeClearOnClickInputs() {
@@ -183,15 +199,7 @@
       });
     };
     $(document).on("ready page:load turbolinks:load", function() {
-      var observer = new MutationObserver(function() {
-        return onDOMReady();
-      });
-      onDOMReady();
-      initializeClearOnClickInputs();
-      observer.observe(document.body, {
-        childList: true,
-        subtree: true
-      });
+      return onDOMReady();
     });
   })(jQuery);
   (function($) {

--- a/app/assets/javascripts/beyond_canvas/base.js
+++ b/app/assets/javascripts/beyond_canvas/base.js
@@ -158,22 +158,14 @@
     };
     var updateInputLabel = function updateInputLabel() {
       $("form").on("change", 'input[type="file"]', function(_ref) {
+        var _input$value;
         var input = _ref.currentTarget;
         var label = $(".input__file__text." + input.getAttribute("id"));
+        if (!label) return;
         var noFileText = input.getAttribute("data-no-file-text");
         var svgFileIcon = '\n        <svg class="input__file__icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">\n          <path d="M15 2v5h5v15h-16v-20h11zm1-2h-14v24h20v-18l-6-6z"/>\n        </svg>';
-        if (!label) return;
-        var fileName = "";
-        if (input.files && input.files.length > 1) {
-          fileName = (input.getAttribute("data-multiple-caption") || "{count} files selected").replace("{count}", input.files.length);
-        } else if (input.value) {
-          fileName = input.value.split("\\").pop();
-        }
-        if (fileName) {
-          label.html("" + svgFileIcon + fileName);
-        } else {
-          label.html(noFileText);
-        }
+        var fileName = input.files && input.files.length > 1 ? (input.getAttribute("data-multiple-caption") || "{count} files selected").replace("{count}", input.files.length) : ((_input$value = input.value) == null ? void 0 : _input$value.split("\\").pop()) && "";
+        fileName ? label.html("" + svgFileIcon + fileName) : label.html(noFileText);
       });
     };
     var addInputFocusClass = function addInputFocusClass() {

--- a/app/assets/javascripts/beyond_canvas/base.js
+++ b/app/assets/javascripts/beyond_canvas/base.js
@@ -158,13 +158,13 @@
     };
     var updateInputLabel = function updateInputLabel() {
       $("form").on("change", 'input[type="file"]', function(_ref) {
-        var _input$value;
+        var _input$files, _input$getAttribute, _input$value;
         var input = _ref.currentTarget;
         var label = $(".input__file__text." + input.getAttribute("id"));
         if (!label) return;
         var noFileText = input.getAttribute("data-no-file-text");
         var svgFileIcon = '\n        <svg class="input__file__icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">\n          <path d="M15 2v5h5v15h-16v-20h11zm1-2h-14v24h20v-18l-6-6z"/>\n        </svg>';
-        var fileName = input.files && input.files.length > 1 ? (input.getAttribute("data-multiple-caption") || "{count} files selected").replace("{count}", input.files.length) : ((_input$value = input.value) == null ? void 0 : _input$value.split("\\").pop()) && "";
+        var fileName = ((_input$files = input.files) == null ? void 0 : _input$files.length) > 1 ? (_input$getAttribute = input.getAttribute("data-multiple-selection-text")) == null ? void 0 : _input$getAttribute.replace("{count}", input.files.length) : ((_input$value = input.value) == null ? void 0 : _input$value.split("\\").pop()) || "";
         fileName ? label.html("" + svgFileIcon + fileName) : label.html(noFileText);
       });
     };

--- a/app/form_builders/beyond_canvas/form_builder.rb
+++ b/app/form_builders/beyond_canvas/form_builder.rb
@@ -60,11 +60,11 @@ module BeyondCanvas
         custom_attributes = {
                               data: {
                                       multiple_selection_text: '{count} files selected',
-                                      no_file_text: args[:data][:no_file_text] || 'No file chosen'
+                                      no_file_text: args.dig(:data, :no_file_text) || 'No file chosen'
                               }
                             }
 
-        custom_attributes[:data].merge! args[:data]
+        custom_attributes[:data].merge! args[:data] if args.has_key? :data
         args.merge!(custom_attributes)
 
         @template.content_tag(:div, class: 'input__file') do
@@ -72,10 +72,10 @@ module BeyondCanvas
             @template.content_tag(:label,
                                   for: filed_identifyer,
                                   class: 'input__file__control button__transparent--primary') do
-              args[:data][:button_text] || 'Choose file'
+              args.dig(:data, :button_text) || 'Choose file'
             end +
             @template.content_tag(:span,
-                                  args[:data][:no_file_text],
+                                  args.dig(:data, :no_file_text),
                                   class: "input__file__text #{filed_identifyer}")
         end
       end

--- a/app/form_builders/beyond_canvas/form_builder.rb
+++ b/app/form_builders/beyond_canvas/form_builder.rb
@@ -57,8 +57,15 @@ module BeyondCanvas
         args.merge!(id: filed_identifyer)
             .merge!(style: 'visibility: hidden; position: absolute;')
 
-        custom_attributes = { data: { multiple_selection_text: '{count} files selected' } }
-        args = custom_attributes.merge!(args)
+        custom_attributes = {
+                              data: {
+                                      multiple_selection_text: '{count} files selected',
+                                      no_file_text: args[:data][:no_file_text] || 'No file chosen'
+                              }
+                            }
+
+        custom_attributes[:data].merge! args[:data]
+        args.merge!(custom_attributes)
 
         @template.content_tag(:div, class: 'input__file') do
           super(attribute, args) +
@@ -68,7 +75,7 @@ module BeyondCanvas
               args[:data][:button_text] || 'Choose file'
             end +
             @template.content_tag(:span,
-                                  args[:data][:no_file_text] || 'No file chosen',
+                                  args[:data][:no_file_text],
                                   class: "input__file__text #{filed_identifyer}")
         end
       end

--- a/app/javascript/beyond_canvas/initializers/inputs.js
+++ b/app/javascript/beyond_canvas/initializers/inputs.js
@@ -10,37 +10,29 @@
     $('form').on('change', 'input[type="file"]', function ({ currentTarget: input }) {
       const label = $(`.input__file__text.${input.getAttribute('id')}`);
 
-      if(!label) return;
+      if (!label) return;
 
       const noFileText = input.getAttribute('data-no-file-text');
       const svgFileIcon = `
         <svg class="input__file__icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
           <path d="M15 2v5h5v15h-16v-20h11zm1-2h-14v24h20v-18l-6-6z"/>
         </svg>`;
-      let fileName = '';
 
-      if (input.files && input.files.length > 1) {
-        fileName = (input.getAttribute('data-multiple-caption') || '{count} files selected').replace(
+      const fileName = (input.files && input.files.length > 1) ?
+        (input.getAttribute('data-multiple-caption') || '{count} files selected').replace(
           '{count}',
           input.files.length
-        );
-      } else if (input.value) {
-        fileName = input.value.split('\\').pop();
-      }
+        ) :
+        input.value?.split('\\').pop() && '';
 
-      if (fileName) {
-        // Adds icon + filename to label
-        label.html(`${svgFileIcon}${fileName}`);
-      } else {
-        // Adds default no-file text
-        label.html(noFileText);
-      }
+      // Adds icon + filename to label or default no-file text
+      fileName ? label.html(`${svgFileIcon}${fileName}`) : label.html(noFileText);
     });
   };
 
   const addInputFocusClass = () => {
     $('form').on('focus', 'input[type="file"]', function ({ currentTarget: input }) {
-        input.addClass('has-focus');
+      input.addClass('has-focus');
     });
   };
 

--- a/app/javascript/beyond_canvas/initializers/inputs.js
+++ b/app/javascript/beyond_canvas/initializers/inputs.js
@@ -1,41 +1,52 @@
 (function ($) {
   const onDOMReady = function () {
-    $('input[type="file"]').each(function () {
-      const $input = $(this);
-      const $label = $(`.input__file__text.${$input.attr('id')}`);
-      const noFileText = $input.attr('data-no-file-text');
+    updateInputLabel();
+    initializeClearOnClickInputs();
+    addInputFocusClass();
+    removeInputFocusClass();
+  };
+
+  const updateInputLabel = () => {
+    $('form').on('change', 'input[type="file"]', function ({ currentTarget: input }) {
+      const label = $(`.input__file__text.${input.getAttribute('id')}`);
+
+      if(!label) return;
+
+      const noFileText = input.getAttribute('data-no-file-text');
       const svgFileIcon = `
         <svg class="input__file__icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
           <path d="M15 2v5h5v15h-16v-20h11zm1-2h-14v24h20v-18l-6-6z"/>
         </svg>`;
+      let fileName = '';
 
-      $input.on('change', function (e) {
-        let fileName = '';
+      if (input.files && input.files.length > 1) {
+        fileName = (input.getAttribute('data-multiple-caption') || '{count} files selected').replace(
+          '{count}',
+          input.files.length
+        );
+      } else if (input.value) {
+        fileName = input.value.split('\\').pop();
+      }
 
-        if (this.files && this.files.length > 1)
-          fileName = (this.getAttribute('data-multiple-caption') || '{count} files selected').replace(
-            '{count}',
-            this.files.length
-          );
-        else if (e.target.value) fileName = e.target.value.split('\\').pop();
+      if (fileName) {
+        // Adds icon + filename to label
+        label.html(`${svgFileIcon}${fileName}`);
+      } else {
+        // Adds default no-file text
+        label.html(noFileText);
+      }
+    });
+  };
 
-        if (fileName) {
-          // Adds icon + filename to label
-          $label.html(`${svgFileIcon}${fileName}`);
-        } else {
-          // Adds default no-file text
-          $label.html(noFileText);
-        }
-      });
+  const addInputFocusClass = () => {
+    $('form').on('focus', 'input[type="file"]', function ({ currentTarget: input }) {
+        input.addClass('has-focus');
+    });
+  };
 
-      // Firefox bug fix
-      $input
-        .on('focus', function () {
-          $input.addClass('has-focus');
-        })
-        .on('blur', function () {
-          $input.removeClass('has-focus');
-        });
+  const removeInputFocusClass = () => {
+    $('form').on('blur', 'input[type="file"]', function ({ currentTarget: input }) {
+      input.removeClass('has-focus');
     });
   };
 
@@ -52,13 +63,5 @@
     });
   };
 
-  $(document).on('ready page:load turbolinks:load', () => {
-    const observer = new MutationObserver(() => onDOMReady());
-
-    onDOMReady();
-    initializeClearOnClickInputs();
-
-    observer.observe(document.body, { childList: true, subtree: true });
-  });
+  $(document).on('ready page:load turbolinks:load', () => onDOMReady());
 })(jQuery);
-

--- a/app/javascript/beyond_canvas/initializers/inputs.js
+++ b/app/javascript/beyond_canvas/initializers/inputs.js
@@ -18,12 +18,12 @@
           <path d="M15 2v5h5v15h-16v-20h11zm1-2h-14v24h20v-18l-6-6z"/>
         </svg>`;
 
-      const fileName = (input.files && input.files.length > 1) ?
-        (input.getAttribute('data-multiple-caption') || '{count} files selected').replace(
+      const fileName = input.files?.length > 1 ?
+        input.getAttribute('data-multiple-selection-text')?.replace(
           '{count}',
           input.files.length
         ) :
-        input.value?.split('\\').pop() && '';
+        input.value?.split('\\').pop() || '';
 
       // Adds icon + filename to label or default no-file text
       fileName ? label.html(`${svgFileIcon}${fileName}`) : label.html(noFileText);

--- a/app/javascript/beyond_canvas/lib/common_functions.js
+++ b/app/javascript/beyond_canvas/lib/common_functions.js
@@ -6,12 +6,12 @@ export function previewImage(e) {
   const figureElement = $(elementFather).find('figure');
   const figurePlaceholderElement = $(e.target).parents('.relative').find('.js-placeholder').find('figure');
 
-  const imgAttr = getImagesAttributes(figureElement, figurePlaceholderElement)
-  const figureAttr = getAttributesFromFigureElements(figureElement, figurePlaceholderElement)
+  const imgAttr = getImagesAttributes(figureElement, figurePlaceholderElement);
+  const figureAttr = getAttributesFromFigureElements(figureElement, figurePlaceholderElement);
 
   delete imgAttr.src;
   delete figureAttr.class;
-  delete figureAttr.style
+  delete figureAttr.style;
 
   if($(e.target).attr('multiple')) {
     $(elementFather).children('attachment__placeholder, [preview]').each((_, img) => $(img).remove());
@@ -46,15 +46,15 @@ const getImagesAttributes = (figureImageElement, figurePlaceholderElement) => {
   return {
     ...getImageAttributes($(figurePlaceholderElement)),
     ...getImageAttributes($(figureImageElement))
-  }
-}
+  };
+};
 
 const getAttributesFromFigureElements = (figureImageElement, figurePlaceholderElement) => {
   return {
     ...getAttributesFromElement($(figurePlaceholderElement)[0]),
     ...getAttributesFromElement($(figureImageElement)[0])
-  }
-}
+  };
+};
 
 export const getImageAttributes = (figureElement) => {
   const svgElement = $(figureElement).find('svg')[0];
@@ -65,7 +65,7 @@ export const getImageAttributes = (figureElement) => {
   }
 
   return getAttributesFromSVG(svgElement);
-}
+};
 
 export const getAttributesFromElement = (element) => {
   const attributes = {};


### PR DESCRIPTION
This PR fix: 
* When there is a change in the DOM it adds a listener for the change event for all input files
* On **FormBuilder** the `file_field` was losing `custom_attributes` when the file_field included `data-attributes`

Also, I discovered that `eslint` was giving errors with sue to the ECMAScript version, for that reason, I allowed until the 2020's version 